### PR TITLE
Fix audio tech credits resetting UI to main menu properties

### DIFF
--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -1415,7 +1415,7 @@ void GamepadUIOptionsPanel::OnCommand( char const* pCommand )
 #else
         V_snwprintf( wszBuf, 4096, L"%S\n\n%S\n\n%S", bink.String(), miles.String(), voice.String() );
 #endif
-		new GamepadUIGenericConfirmationPanel( GamepadUI::GetInstance().GetBasePanel(), "TechCredits", title.String(), wszBuf,
+		new GamepadUIGenericConfirmationPanel( GamepadUIOptionsPanel::GetInstance(), "TechCredits", title.String(), wszBuf,
 		[](){}, true, false);
     }
     else


### PR DESCRIPTION
Closing the 3rd party technology credits dialog in the Options menu causes it to start drawing the main menu behind the Options panel. This PR fixes that by changing the dialog's parent to the Options panel instead of the base panel.

![image](https://user-images.githubusercontent.com/19228257/218635617-857be9de-7653-45d0-adae-2f6f96268cca.png)
![image](https://user-images.githubusercontent.com/19228257/218635641-84dc25e4-0a21-493e-9f5c-a60864fbe30e.png)