### PR TITLE
Add basic mouse support to WheelyWheel

### DIFF
--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -394,6 +394,16 @@ public:
         }
     }
 
+    void FireActionSignal()
+    {
+        BaseClass::FireActionSignal();
+
+        if ( m_Options.Count() )
+            m_nSelectedItem = ( m_nSelectedItem + 1 ) % m_Options.Count();
+        if ( m_bInstantApply )
+            UpdateConVar();
+    }
+
     void UpdateConVar() OVERRIDE
     {
         if ( IsDirty() )


### PR DESCRIPTION
The original version of WheelyWheel has an issue where clicking with the mouse doesn't do anything. This fixes the issue.