### PR TITLE
Fix options menu scrolling incorrectly when hovering over tabs + better header scrolling

### DIFF
--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -1682,16 +1682,32 @@ void GamepadUIOptionsPanel::OnGamepadUIButtonNavigatedTo( vgui::VPANEL button )
         if ( nY + m_flFooterButtonsOffsetY + m_nFooterButtonHeight + pButton->GetTall() > nParentH || nY < m_flTabsOffsetY + flTabButtonHeight )
         {
             int nTargetY = 0;
-            for ( GamepadUIButton *pFindButton : m_Tabs[ GetActiveTab() ].pButtons )
+            int nThisButton = -1;
+            int nHeader = -1;
+            for ( int i = 0; i < m_Tabs[ GetActiveTab() ].pButtons.Count(); i++ )
             {
-                if ( pFindButton == pButton )
+                if ( m_Tabs[ GetActiveTab() ].pButtons[i] == pButton)
+                {
+                    nThisButton = i;
                     break;
-                nTargetY += pFindButton->m_flHeight;
+                }
+				
+                // For now, headers can be identified as disabled buttons
+                if (!m_Tabs[GetActiveTab()].pButtons[i]->IsEnabled())
+                    nHeader = i;
+                else
+                    nHeader = -1;
+
+                nTargetY += m_Tabs[ GetActiveTab() ].pButtons[i]->m_flHeight;
             }
 
-            // Hack for section headers
-            if ( m_Tabs[ GetActiveTab() ].pButtons.Count() >= 2 && m_Tabs[ GetActiveTab() ].pButtons[ 1 ] == pButton )
-                nTargetY = 0;
+            // This button isn't part of the current tab, so don't scroll
+            if (nThisButton == -1)
+                return;
+
+            // If this button has a section header above it and we're going up, scroll to it
+            if ( nHeader != -1 && nY < nParentH / 2 )
+                nTargetY -= m_Tabs[ GetActiveTab() ].pButtons[ nHeader ]->m_flHeight;
 
             if ( nY < nParentH / 2 )
             {


### PR DESCRIPTION
When hovering over an options tab with the mouse, the vertical list of options will scroll unpredictably, as mentioned in https://github.com/Joshua-Ashton/HL2-GamepadUI/issues/22. This PR changes how the Options panel's navigation code updates the scroll state so that it ignores any button that isn't part of the currently selected tab.

Additionally, this PR adds better recognition for section headers so that they're always shown when the button below them is navigated to, replacing a hack which only did so with headers at the beginning of the list of options.