### PR TITLE
Configurable button sounds

### DIFF
--- a/src/game/gamepadui/gamepadui_button.cpp
+++ b/src/game/gamepadui/gamepadui_button.cpp
@@ -8,10 +8,8 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-// Quick definitions for button sounds.
-// These ideally will be merged to the scheme config someday. (Madi)
-#define BTN_ARMED_SOUND "UI/buttonrollover.wav"
-#define BNT_RELEASED_SOUND "UI/buttonclickrelease.wav"
+#define DEFAULT_BTN_ARMED_SOUND "ui/buttonrollover.wav"
+#define DEFAULT_BTN_RELEASED_SOUND "ui/buttonclickrelease.wav"
 
 
 GamepadUIButton::GamepadUIButton( vgui::Panel *pParent, vgui::Panel* pActionSignalTarget, const char *pSchemeFile, const char *pCommand, const char *pText, const char *pDescription )
@@ -33,13 +31,22 @@ GamepadUIButton::GamepadUIButton( vgui::Panel *pParent, vgui::Panel* pActionSign
 void GamepadUIButton::ApplySchemeSettings(vgui::IScheme* pScheme)
 {
     BaseClass::ApplySchemeSettings(pScheme);
+	
+    const char *pButtonSound = pScheme->GetResourceString( "Button.Sound.Armed" );
+    if (pButtonSound && *pButtonSound)
+        SetArmedSound( pButtonSound );
+    else
+        SetArmedSound( DEFAULT_BTN_ARMED_SOUND );
 
-    // TODO: Add me to scheme config stuff eventually.
-    // right now this is hardcoded for Half-Life 2/Portal
-    // etc, but modders might want to play around more.
-    SetArmedSound( BTN_ARMED_SOUND );
-    SetReleasedSound( BNT_RELEASED_SOUND );
-    SetDepressedSound( NULL );
+    pButtonSound = pScheme->GetResourceString( "Button.Sound.Released" );
+    if (pButtonSound && *pButtonSound)
+        SetReleasedSound( pButtonSound );
+    else
+        SetReleasedSound( DEFAULT_BTN_RELEASED_SOUND );
+
+    pButtonSound = pScheme->GetResourceString( "Button.Sound.Depressed" );
+    if (pButtonSound && *pButtonSound)
+        SetDepressedSound( pButtonSound );
 
     SetPaintBorderEnabled( false );
     SetPaintBackgroundEnabled( false );


### PR DESCRIPTION
This PR adds scheme settings for button arm, release, and depress sounds. This allows them to be changed and configured on a panel-by-panel basis.

For example:
```
		"Button.Sound.Armed"					"ui/buttonrollover.wav"
		"Button.Sound.Released"					"ui/buttonclickrelease.wav"
```
```diff
	"BaseSettings"
	{

		"Button.Width.Out"						"648"
		"Button.Width.Over"						"648"
		"Button.Width.Pressed"					"648"

		"Button.Height.Out"						"28"
		"Button.Height.Over"					"28"
		"Button.Height.Pressed"					"28"

		"Button.Description.Hide.Out"					"1"
		"Button.Description.Hide.Over"					"1"
		"Button.Description.Hide.Pressed"				"1"
		"Button.Description.Hide.Animation.Duration"	"0"

		"Button.Binding.Width"							"80"
		"Button.Binding.Height"							"16"
		
+		"Button.Sound.Armed"					"ui/buttonrollover.wav"
+		"Button.Sound.Released"					"common/null.wav"
+		"Button.Sound.Depressed"				"physics/concrete/rock_impact_soft2.wav"
	}
```

All panels are still hardcoded to use `ui/buttonrollover.wav` for the arm sound and `ui/buttonclickrelease.wav` for the release sound if the values are blank, so in cases where a button should be silent, a dummy sound file (e.g. `common/null.wav`) will need to be used.