### PR TITLE
Add really experimental string support to WheelyWheel

### DIFF
--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -1865,13 +1865,14 @@ void GamepadUIOptionsPanel::LoadOptionTabs( const char *pszOptionsFile )
                         KeyValues *pOptions = pItemData->FindKey( "options" );
                         if ( pOptions )
                         {
+                            int i = 0;
                             for ( KeyValues* pOptionData = pOptions->GetFirstSubKey(); pOptionData != NULL; pOptionData = pOptionData->GetNextKey() )
                             {
                                 GamepadUIOption option;
                                 if (bUsesString)
                                 {
                                     option.userdata.strVal = pOptionData->GetName();
-                                    option.nValue = 0;
+                                    option.nValue = i;
                                 }
                                 else
                                 {
@@ -1880,6 +1881,7 @@ void GamepadUIOptionsPanel::LoadOptionTabs( const char *pszOptionsFile )
 
                                 option.strOptionText = GamepadUIString( pOptionData->GetString() );
                                 button->AddOptionItem( option );
+                                ++i;
                             }
                         }
                         else if ( pszOptionsFrom && *pszOptionsFrom )


### PR DESCRIPTION
Attempt to resolve #5.

This adds an additional userdata value to GamepadUIOption, allowing one to use a string value alongside or to replace the nValue variable.

Alongside this, the usesstring value has been added to allow the WheelyWheel element to read the value as a string and not an int or float. 

Why is there a seperate value? This was done to reduce the amount of conflicts. The nvalue statement also works as an index, so you can iliterate through values with usesstring.

this is extremely experimental, but works fine in testing.