### PR TITLE
Simple aspect ratio scaling

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1307,6 +1307,11 @@ int CHLClient::HudVidInit( void )
 
 	GetClientVoiceMgr()->VidInit();
 
+#if defined(GAMEPADUI)
+	if (g_pGamepadUI != nullptr)
+		g_pGamepadUI->VidInit();
+#endif // GAMEPADUI
+
 	return 1;
 }
 

--- a/src/game/gamepadui/gamepadui_bonusmaps.cpp
+++ b/src/game/gamepadui/gamepadui_bonusmaps.cpp
@@ -199,6 +199,24 @@ public:
             vgui::surface()->DrawSetTexture( 0 );
         }
     }
+	
+    void ApplySchemeSettings( vgui::IScheme *pScheme )
+    {
+        BaseClass::ApplySchemeSettings( pScheme );
+
+        if (GamepadUI::GetInstance().GetScreenRatio() != 1.0f)
+        {
+            float flScreenRatio = GamepadUI::GetInstance().GetScreenRatio();
+
+            // For now, undo the scaling from base class
+            m_flWidth /= flScreenRatio;
+            for (int i = 0; i < ButtonStates::Count; i++)
+                m_flWidthAnimationValue[i] /= flScreenRatio;
+
+            SetSize( m_flWidth, m_flHeight + m_flExtraHeight );
+            DoAnimations( true );
+        }
+    }
 
     void NavigateTo() OVERRIDE
     {
@@ -307,6 +325,12 @@ void GamepadUIBonusMapsPanel::ApplySchemeSettings( vgui::IScheme* pScheme )
 {
     BaseClass::ApplySchemeSettings( pScheme );
     m_hGoalFont = pScheme->GetFont( "Goal.Font", true );
+
+    if (GamepadUI::GetInstance().GetScreenRatio() != 1.0f)
+    {
+        float flScreenRatio = GamepadUI::GetInstance().GetScreenRatio();
+        m_BonusOffsetX *= flScreenRatio;
+    }
 }
 
 void GamepadUIBonusMapsPanel::OnGamepadUIButtonNavigatedTo( vgui::VPANEL button )

--- a/src/game/gamepadui/gamepadui_button.cpp
+++ b/src/game/gamepadui/gamepadui_button.cpp
@@ -63,6 +63,15 @@ void GamepadUIButton::ApplySchemeSettings(vgui::IScheme* pScheme)
         else
             m_flCachedExtraHeight = 0.0f;
     }
+	
+    if (GamepadUI::GetInstance().GetScreenRatio() != 1.0f)
+    {
+        float flScreenRatio = GamepadUI::GetInstance().GetScreenRatio();
+
+        m_flWidth *= flScreenRatio;
+        for (int i = 0; i < ButtonStates::Count; i++)
+            m_flWidthAnimationValue[i] *= flScreenRatio;
+    }
 
     SetSize( m_flWidth, m_flHeight + m_flExtraHeight );
     DoAnimations( true );

--- a/src/game/gamepadui/gamepadui_interface.cpp
+++ b/src/game/gamepadui/gamepadui_interface.cpp
@@ -132,6 +132,29 @@ void GamepadUI::OnLevelShutdown()
     GetMainMenu()->OnMenuStateChanged();
 }
 
+void GamepadUI::VidInit()
+{
+    int w, h;
+    vgui::surface()->GetScreenSize( w, h );
+
+    Assert( w != 0 && h != 0 );
+
+    // Scale elements proportional to the aspect ratio's distance from 16:10
+    const float flDefaultInvAspect = 0.625f;
+    float flInvAspectRatio = ((float)h) / ((float)w);
+
+    if (flInvAspectRatio != flDefaultInvAspect)
+    {
+        m_flScreenRatio = 1.0f - (flInvAspectRatio - flDefaultInvAspect);
+    }
+    else
+    {
+        m_flScreenRatio = 1.0f;
+    }
+
+    m_pBasePanel->InvalidateLayout( false, true );
+}
+
 
 bool GamepadUI::IsInLevel() const
 {

--- a/src/game/gamepadui/gamepadui_interface.h
+++ b/src/game/gamepadui/gamepadui_interface.h
@@ -44,6 +44,8 @@ public:
     void OnLevelInitializePreEntity() OVERRIDE;
     void OnLevelInitializePostEntity() OVERRIDE;
     void OnLevelShutdown() OVERRIDE;
+	
+    void VidInit() OVERRIDE;
 
     bool IsInLevel() const;
     bool IsInBackgroundLevel() const;
@@ -75,6 +77,8 @@ public:
     void ResetToMainMenuGradients();
 
     CSteamAPIContext* GetSteamAPIContext() { return &m_SteamAPIContext; }
+	
+    float GetScreenRatio() const { return m_flScreenRatio; }
 
 private:
 
@@ -97,6 +101,8 @@ private:
     CSteamAPIContext m_SteamAPIContext;
 
     GamepadUIMainMenu* GetMainMenu() const;
+	
+    float   m_flScreenRatio = 1.0f;
 
     static GamepadUI *s_pGamepadUI;
 };

--- a/src/game/gamepadui/gamepadui_newgame.cpp
+++ b/src/game/gamepadui/gamepadui_newgame.cpp
@@ -53,6 +53,7 @@ public:
     void UpdateGradients();
 
     void OnThink() OVERRIDE;
+    void ApplySchemeSettings( vgui::IScheme *pScheme ) OVERRIDE;
     void OnCommand( char const* pCommand ) OVERRIDE;
 
     MESSAGE_FUNC_HANDLE( OnGamepadUIButtonNavigatedTo, "OnGamepadUIButtonNavigatedTo", button );
@@ -127,6 +128,28 @@ public:
         }
 
         PaintText();
+    }
+	
+    void ApplySchemeSettings( vgui::IScheme* pScheme )
+    {
+        BaseClass::ApplySchemeSettings( pScheme );
+
+        if (GamepadUI::GetInstance().GetScreenRatio() != 1.0f)
+        {
+            float flScreenRatio = GamepadUI::GetInstance().GetScreenRatio();
+
+            m_flHeight *= flScreenRatio;
+            for (int i = 0; i < ButtonStates::Count; i++)
+                m_flHeightAnimationValue[i] *= flScreenRatio;
+
+            // Also change the text offset
+            m_flTextOffsetY *= flScreenRatio;
+            for (int i = 0; i < ButtonStates::Count; i++)
+                m_flTextOffsetYAnimationValue[i] *= flScreenRatio;
+
+            SetSize( m_flWidth, m_flHeight + m_flExtraHeight );
+            DoAnimations( true );
+        }
     }
 
     void NavigateTo() OVERRIDE
@@ -302,6 +325,17 @@ void GamepadUINewGamePanel::OnThink()
     BaseClass::OnThink();
 
     LayoutChapterButtons();
+}
+
+void GamepadUINewGamePanel::ApplySchemeSettings( vgui::IScheme* pScheme )
+{
+    BaseClass::ApplySchemeSettings( pScheme );
+
+    if (GamepadUI::GetInstance().GetScreenRatio() != 1.0f)
+    {
+        float flScreenRatio = GamepadUI::GetInstance().GetScreenRatio();
+        m_ChapterOffsetX *= (flScreenRatio*flScreenRatio);
+    }
 }
 
 void GamepadUINewGamePanel::OnGamepadUIButtonNavigatedTo( vgui::VPANEL button )

--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -70,6 +70,8 @@ public:
     void UpdateGradients() OVERRIDE;
 
     void LoadOptionTabs( const char* pszOptionsFile );
+	
+    void ApplySchemeSettings( vgui::IScheme *pScheme ) OVERRIDE;
 
     void SetActiveTab( int nTab );
     int GetActiveTab();
@@ -2004,6 +2006,17 @@ void GamepadUIOptionsPanel::LoadOptionTabs( const char *pszOptionsFile )
 
             m_nTabCount++;
         }
+    }
+}
+
+void GamepadUIOptionsPanel::ApplySchemeSettings( vgui::IScheme* pScheme )
+{
+    BaseClass::ApplySchemeSettings( pScheme );
+    
+    if (GamepadUI::GetInstance().GetScreenRatio() != 1.0f)
+    {
+        float flScreenRatio = GamepadUI::GetInstance().GetScreenRatio();
+        m_flTabsOffsetX *= (flScreenRatio * flScreenRatio);
     }
 }
 

--- a/src/game/gamepadui/igamepadui.h
+++ b/src/game/gamepadui/igamepadui.h
@@ -19,6 +19,8 @@ public:
     virtual void OnLevelInitializePreEntity() = 0;
     virtual void OnLevelInitializePostEntity() = 0;
     virtual void OnLevelShutdown() = 0;
+	
+    virtual void VidInit() = 0;
 };
 
 #define GAMEPADUI_INTERFACE_VERSION "GamepadUI001"


### PR DESCRIPTION
The Gamepad UI currently scales improperly on non-16:10 resolutions. This is most apparent when using 4:3:

<p align="center">
<img src="https://user-images.githubusercontent.com/19228257/219475168-5e6b17c2-5676-443c-8198-cc30df175d2e.jpg" width="616"/>
</p>

---

This PR allows the menu to dynamically scale the width of buttons and certain frame offsets to non-16:10 aspect ratios without any configuration needed.

---

<p align="center"><b>16:10</b> (default, unchanged)</p>
<p align="center">
<img src="https://user-images.githubusercontent.com/19228257/219473641-896bc290-1852-442e-828e-12668f7943c4.jpg" width="704"/>
</p>
<p align="center"><b>16:9</b></p>
<p align="center">
<img src="https://user-images.githubusercontent.com/19228257/219473669-23e51197-85a9-4132-a645-3d2b9b159e31.jpg" width="748"/>
</p>
<p align="center"><b>4:3</b></p>
<p align="center">
<img src="https://user-images.githubusercontent.com/19228257/219473686-12da1fdc-8526-40f6-a16b-965e563fe3cf.jpg" width="616"/>
</p>

---

This implementation isn't perfect and any new panels with custom offsets or buttons may need to account for this in their code, but I'm hoping this can otherwise be a reliable solution to the aspect ratio problem for the time being.