### PR TITLE
"Use Defaults" footer button for keyboard settings

### DIFF
--- a/src/game/gamepadui/gamepadui_button.h
+++ b/src/game/gamepadui/gamepadui_button.h
@@ -42,11 +42,12 @@ namespace FooterButtons
         Commentary  = ( 1 << 6 ),
         BonusMaps  = ( 1 << 7 ),
         Challenge  = ( 1 << 8 ),
+        UseDefaults  = ( 1 << 9 ),
 
         // Buttons that are 'confirmatory'
         ConfirmMask = ( LeftSelect | Select | Okay ),
     };
-    static const int MaxFooterButtons = 9;
+    static const int MaxFooterButtons = 10;
 
     inline const char* GetButtonName( FooterButton button )
     {
@@ -61,6 +62,7 @@ namespace FooterButtons
             case Commentary: return "#GameUI_Commentary";
             case BonusMaps: return "#Deck_BonusMaps";
             case Challenge: return "#Deck_Challenges";
+            case UseDefaults: return "#GameUI_UseDefaults";
         }
         return "Unknown";
     }
@@ -78,6 +80,7 @@ namespace FooterButtons
             case Commentary: return "action_commentary";
             case BonusMaps: return "action_bonus_maps";
             case Challenge: return "action_challenges";
+            case UseDefaults: return "action_usedefaults";
         }
         return "";
     }
@@ -95,6 +98,7 @@ namespace FooterButtons
             case Commentary: return "menu_y";
             case BonusMaps: return "menu_x";
             case Challenge: return "menu_y";
+            case UseDefaults: return "menu_x";
         }
         return "";
     }

--- a/src/game/gamepadui/gamepadui_frame.cpp
+++ b/src/game/gamepadui/gamepadui_frame.cpp
@@ -256,7 +256,7 @@ void GamepadUIFrame::OnKeyCodePressed( vgui::KeyCode code )
     case KEY_XBUTTON_X:
         for ( int i = 0; i < FooterButtons::MaxFooterButtons; i++ )
         {
-            if ( FooterButtons::GetButtonByIdx(i) & ( FooterButtons::BonusMaps ) )
+            if ( FooterButtons::GetButtonByIdx(i) & ( FooterButtons::BonusMaps | FooterButtons::UseDefaults ) )
             {
                 if ( m_pFooterButtons[i] )
                     m_pFooterButtons[i]->ForceDepressed( true );
@@ -340,7 +340,7 @@ void GamepadUIFrame::OnKeyCodeReleased( vgui::KeyCode code )
     case KEY_XBUTTON_X:
         for ( int i = 0; i < FooterButtons::MaxFooterButtons; i++ )
         {
-            if ( FooterButtons::GetButtonByIdx(i) & ( FooterButtons::BonusMaps ) )
+            if ( FooterButtons::GetButtonByIdx(i) & ( FooterButtons::BonusMaps | FooterButtons::UseDefaults ) )
             {
                 if ( m_pFooterButtons[i] )
                 {


### PR DESCRIPTION
This adds a new footer button to GamepadUI's keyboard settings which resets all keys to their default binds. Equivalent to the button of the same name in regular GameUI settings.