### PR TITLE
"Advanced" keyboard options

### DIFF
--- a/game/mod_hl2/gamepadui/options.res
+++ b/game/mod_hl2/gamepadui/options.res
@@ -40,6 +40,41 @@
 		"title"			"#GameUI_Keyboard"
 		"items_from"	"keyboard"
 		"alternating"   "1"
+		"items"
+		{
+			"AdvancedHeader"
+			{
+				"text"			"#GameUI_AdvancedNoEllipsis"
+				"type"			"headeryheader"
+				"advanced"		"1"
+			}
+			
+			"FastWeaponSwitch"
+			{
+				"text"			"#GameUI_FastSwitchCheck"
+				"type"			"wheelywheel"
+				"convar"		"hud_fastswitch"
+
+				"options"
+				{
+					"0"		"#gameui_disabled"
+					"1"		"#gameui_enabled"
+				}
+			}
+			
+			"DeveloperConsole"
+			{
+				"text"			"#GameUI_DeveloperConsoleCheck"
+				"type"			"wheelywheel"
+				"convar"		"con_enable"
+
+				"options"
+				{
+					"0"		"#gameui_disabled"
+					"1"		"#gameui_enabled"
+				}
+			}
+		}
 	}
 	"Mouse"
 	{

--- a/game/mod_portal/gamepadui/options.res
+++ b/game/mod_portal/gamepadui/options.res
@@ -57,6 +57,41 @@
 		"title"			"#GameUI_Keyboard"
 		"items_from"	"keyboard"
 		"alternating"   "1"
+		"items"
+		{
+			"AdvancedHeader"
+			{
+				"text"			"#GameUI_AdvancedNoEllipsis"
+				"type"			"headeryheader"
+				"advanced"		"1"
+			}
+			
+			"FastWeaponSwitch"
+			{
+				"text"			"#GameUI_FastSwitchCheck"
+				"type"			"wheelywheel"
+				"convar"		"hud_fastswitch"
+
+				"options"
+				{
+					"0"		"#gameui_disabled"
+					"1"		"#gameui_enabled"
+				}
+			}
+			
+			"DeveloperConsole"
+			{
+				"text"			"#GameUI_DeveloperConsoleCheck"
+				"type"			"wheelywheel"
+				"convar"		"con_enable"
+
+				"options"
+				{
+					"0"		"#gameui_disabled"
+					"1"		"#gameui_enabled"
+				}
+			}
+		}
 	}
 	"Mouse"
 	{

--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -1763,6 +1763,68 @@ void GamepadUIOptionsPanel::LoadOptionTabs( const char *pszOptionsFile )
             m_Tabs[ m_nTabCount ].bAlternating = pTabData->GetBool( "alternating" );
             m_Tabs[ m_nTabCount ].bHorizontal = pTabData->GetBool( "horizontal" );
 
+            if ( !V_strcmp( pTabData->GetString( "items_from" ), "keyboard" ) )
+            {
+	            char szBinding[256];
+	            char szDescription[256];
+
+	            // Load the default keys list
+	            CUtlBuffer buf( 0, 0, CUtlBuffer::TEXT_BUFFER );
+	            if ( !g_pFullFileSystem->ReadFile( "scripts/kb_act.lst", NULL, buf ) )
+		            return;
+
+	            const char *data = ( const char* )buf.Base();
+
+	            char token[512];
+	            while ( 1 )
+	            {
+		            data = UTIL_Parse( data, token, sizeof( token ) );
+		            // Done.
+		            if ( strlen( token ) <= 0 )
+			            break;
+
+		            Q_strncpy( szBinding, token, sizeof( szBinding ) );
+
+		            data = UTIL_Parse( data, token, sizeof( token ) );
+		            if ( strlen( token ) <= 0 )
+		            {
+			            break;
+		            }
+
+		            Q_strncpy( szDescription, token, sizeof( szDescription ) );
+
+		            // Skip '======' rows
+		            if ( szDescription[ 0 ] != '=' )
+		            {
+			            // Flag as special header row if binding is "blank"
+			            if ( !stricmp( szBinding, "blank" ) )
+			            {
+				            // add header item
+                            auto button = new GamepadUIButton(
+                                this, this,
+                                GAMEPADUI_RESOURCE_FOLDER "schemeoptions_sectiontitle.res",
+                                "button_pressed",
+                                szDescription, "" );
+                            //button->SetFooterButton( true );
+                            button->SetEnabled( false );
+                            m_Tabs[ m_nTabCount ].pButtons.AddToTail( button );
+			            }
+			            else
+			            {
+				            // Add to list
+                            auto button = new GamepadUIKeyButton(
+                                szBinding, this, this,
+                                GAMEPADUI_RESOURCE_FOLDER "schemeoptions_wheelywheel.res",
+                                "button_pressed",
+                                szDescription, "" );
+                            m_Tabs[ m_nTabCount ].pButtons.AddToTail( button );
+			            }
+		            }
+	            }
+
+                FillInBindings();
+            }
+
             KeyValues* pTabItems = pTabData->FindKey( "items" );
             if ( pTabItems )
             {
@@ -1923,68 +1985,6 @@ void GamepadUIOptionsPanel::LoadOptionTabs( const char *pszOptionsFile )
                         m_Tabs[ m_nTabCount ].pButtons.AddToTail( button );
                     }
                 }
-            }
-
-            if ( !V_strcmp( pTabData->GetString( "items_from" ), "keyboard" ) )
-            {
-	            char szBinding[256];
-	            char szDescription[256];
-
-	            // Load the default keys list
-	            CUtlBuffer buf( 0, 0, CUtlBuffer::TEXT_BUFFER );
-	            if ( !g_pFullFileSystem->ReadFile( "scripts/kb_act.lst", NULL, buf ) )
-		            return;
-
-	            const char *data = ( const char* )buf.Base();
-
-	            char token[512];
-	            while ( 1 )
-	            {
-		            data = UTIL_Parse( data, token, sizeof( token ) );
-		            // Done.
-		            if ( strlen( token ) <= 0 )
-			            break;
-
-		            Q_strncpy( szBinding, token, sizeof( szBinding ) );
-
-		            data = UTIL_Parse( data, token, sizeof( token ) );
-		            if ( strlen( token ) <= 0 )
-		            {
-			            break;
-		            }
-
-		            Q_strncpy( szDescription, token, sizeof( szDescription ) );
-
-		            // Skip '======' rows
-		            if ( szDescription[ 0 ] != '=' )
-		            {
-			            // Flag as special header row if binding is "blank"
-			            if ( !stricmp( szBinding, "blank" ) )
-			            {
-				            // add header item
-                            auto button = new GamepadUIButton(
-                                this, this,
-                                GAMEPADUI_RESOURCE_FOLDER "schemeoptions_sectiontitle.res",
-                                "button_pressed",
-                                szDescription, "" );
-                            //button->SetFooterButton( true );
-                            button->SetEnabled( false );
-                            m_Tabs[ m_nTabCount ].pButtons.AddToTail( button );
-			            }
-			            else
-			            {
-				            // Add to list
-                            auto button = new GamepadUIKeyButton(
-                                szBinding, this, this,
-                                GAMEPADUI_RESOURCE_FOLDER "schemeoptions_wheelywheel.res",
-                                "button_pressed",
-                                szDescription, "" );
-                            m_Tabs[ m_nTabCount ].pButtons.AddToTail( button );
-			            }
-		            }
-	            }
-
-                FillInBindings();
             }
 
             CUtlVector< GamepadUIButton* >& pButtons = m_Tabs[ m_nTabCount ].pButtons;


### PR DESCRIPTION
This adds the options from GameUI's "Advanced" keyboard settings to the bottom of GamepadUI's keyboard settings.

Note that this also swaps the parsing order of `items_from` and `items` so that the new options appear below the keyboard binds.

---

![image](https://user-images.githubusercontent.com/19228257/221214939-f9c469e5-59f1-40bd-838a-d8704be6144f.png)