### PR TITLE
Remove references to hud_aspect in SDK 2013

### DIFF
--- a/game/mod_hl2/gamepadui/options.res
+++ b/game/mod_hl2/gamepadui/options.res
@@ -262,22 +262,6 @@
 				"options_from"	"displaymode"
 			}
 
-			"HUDAspectRatio"
-			{
-				"text"			"#GameUI_HUDAspectRatio"
-				"type"			"wheelywheel"
-
-				"convar"		"_gamepadui_hudaspect"
-				"instantapply"	"1"
-				"options"
-				{
-					"0"			"#GameUI_Achievement_Unlocked"
-					"1"			"#GameUI_AspectNormal"
-					"2"			"#GameUI_AspectWide16x9"
-					"3"			"#GameUI_AspectWide16x10"
-				}
-			}
-
 			"AdvancedHeader"
 			{
 				"text"			"#GameUI_AdvancedNoEllipsis"

--- a/game/mod_portal/gamepadui/options.res
+++ b/game/mod_portal/gamepadui/options.res
@@ -279,22 +279,6 @@
 				"options_from"	"displaymode"
 			}
 
-			"HUDAspectRatio"
-			{
-				"text"			"#GameUI_HUDAspectRatio"
-				"type"			"wheelywheel"
-
-				"convar"		"_gamepadui_hudaspect"
-				"instantapply"	"1"
-				"options"
-				{
-					"0"			"#GameUI_Achievement_Unlocked"
-					"1"			"#GameUI_AspectNormal"
-					"2"			"#GameUI_AspectWide16x9"
-					"3"			"#GameUI_AspectWide16x10"
-				}
-			}
-
 			"AdvancedHeader"
 			{
 				"text"			"#GameUI_AdvancedNoEllipsis"

--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -41,7 +41,9 @@ ConVar _gamepadui_displaymode( "_gamepadui_displaymode", "0", FCVAR_NONE, "", On
 ConVar _gamepadui_resolution( "_gamepadui_resolution", "0" );
 ConVar _gamepadui_sound_quality( "_gamepadui_sound_quality", "0" );
 ConVar _gamepadui_closecaptions( "_gamepadui_closecaptions", "0" );
+#ifdef HL2_RETAIL
 ConVar _gamepadui_hudaspect( "_gamepadui_hudaspect", "0" );
+#endif
 ConVar _gamepadui_skill( "_gamepadui_skill", "0" );
 
 struct GamepadUITab
@@ -944,6 +946,7 @@ int GetCurrentCloseCaptions()
     return 0;
 }
 
+#ifdef HL2_RETAIL
 int GetCurrentHudAspectRatio()
 {
     ConVarRef hud_aspect( "hud_aspect" );
@@ -960,6 +963,7 @@ int GetCurrentHudAspectRatio()
 	else
 		return 0;
 }
+#endif
 
 int GetCurrentSkill()
 {
@@ -1118,6 +1122,7 @@ void FlushPendingCloseCaptions()
 	GamepadUI::GetInstance().GetEngineClient()->ClientCmd_Unrestricted( szCmd );
 }
 
+#ifdef HL2_RETAIL
 void FlushPendingHudAspectRatio()
 {
     ConVarRef hud_aspect( "hud_aspect" );
@@ -1140,6 +1145,7 @@ void FlushPendingHudAspectRatio()
         break;
     }
 }
+#endif
 
 void FlushPendingSkill()
 {
@@ -1156,7 +1162,9 @@ void UpdateHelperConvars()
     _gamepadui_displaymode.SetValue( GetCurrentDisplayMode() );
     _gamepadui_sound_quality.SetValue( GetCurrentSoundQuality() );
     _gamepadui_closecaptions.SetValue( GetCurrentCloseCaptions() );
+#ifdef HL2_RETAIL
     _gamepadui_hudaspect.SetValue( GetCurrentHudAspectRatio() );
+#endif
     _gamepadui_skill.SetValue( GetCurrentSkill() );
 }
 
@@ -1168,7 +1176,9 @@ void FlushHelperConVars()
     FlushPendingResolution();
     FlushPendingSoundQuality();
     FlushPendingCloseCaptions();
+#ifdef HL2_RETAIL
     FlushPendingHudAspectRatio();
+#endif
     FlushPendingSkill();
 }
 


### PR DESCRIPTION
`hud_aspect` does not exist in Source SDK Base 2013 and appears in the menu with an invalid localization token, with the `ConVarRef`s only producing warnings in the console. This PR locks it behind the `HL2_RETAIL` preprocessor and removes it from both games' `options.res`.

I'm assuming removing the option directly from `options.res` is alright since the same is done with the Steam Input menu.