### PR TITLE
Support for unique main menu title keyvalues

### DIFF
--- a/src/game/gamepadui/gamepadui_mainmenu.cpp
+++ b/src/game/gamepadui/gamepadui_mainmenu.cpp
@@ -25,8 +25,8 @@ GamepadUIMainMenu::GamepadUIMainMenu( vgui::Panel* pParent )
     {
         if ( pModData->LoadFromFile( g_pFullFileSystem, "gameinfo.txt" ) )
         {
-            m_LogoText[ 0 ] = pModData->GetString( "title" );
-            m_LogoText[ 1 ] = pModData->GetString( "title2" );
+            m_LogoText[ 0 ] = pModData->GetString( "gamepadui_title", pModData->GetString( "title" ) );
+            m_LogoText[ 1 ] = pModData->GetString( "gamepadui_title2", pModData->GetString( "title2" ) );
         }
         pModData->deleteThis();
     }


### PR DESCRIPTION
This allows GamepadUI to optionally use its own titles (`gamepadui_title` and `gamepadui_title2`) separate from the regular GameUI title keyvalues (`title` and `title2`). It will continue to use the regular GameUI titles by default unless unique GamepadUI titles are specified in `gameinfo.txt`.

This is useful for mods which are unable to replace their `GameUI.dll` and have no qualms about blanking out the regular `title` keyvalues, which works around the issue of the original GameUI logo being visible. This is also useful if separate titles between GameUI and GamepadUI are needed.