### PR TITLE
Fix "Use Defaults" button not appearing

### DIFF
--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -1828,6 +1828,7 @@ void GamepadUIOptionsPanel::LoadOptionTabs( const char *pszOptionsFile )
                 m_Tabs[ m_nTabCount ].pTabButton = button;
             }
 
+            m_Tabs[ m_nTabCount ].pTabButton->SetName( pTabData->GetName() );
             m_Tabs[ m_nTabCount ].bAlternating = pTabData->GetBool( "alternating" );
             m_Tabs[ m_nTabCount ].bHorizontal = pTabData->GetBool( "horizontal" );
 


### PR DESCRIPTION
Fixes https://github.com/Joshua-Ashton/HL2-GamepadUI/issues/36.

When I opened my pull request to add the Use Defaults footer button, I had forgotten to commit a line of code which sets the name of each tab button to their respective key names in `options.res`. Note that this only sets their internal panel names and does not affect their in-game labels.