### PR TITLE
Fix save overwrite confirmation resetting UI to main menu properties

### DIFF
--- a/src/game/gamepadui/gamepadui_savegame.cpp
+++ b/src/game/gamepadui/gamepadui_savegame.cpp
@@ -691,7 +691,7 @@ void GamepadUISaveGamePanel::OnCommand( char const* pCommand )
 				{
 					if ( panel->GetSaveGame()->iTimestamp != NEW_SAVE_GAME_TIMESTAMP )
 					{
-						new GamepadUIGenericConfirmationPanel( GamepadUI::GetInstance().GetBasePanel(), "SaveOverwriteConfirmationPanel", "#GameUI_ConfirmOverwriteSaveGame_Title", "#GameUI_ConfirmOverwriteSaveGame_Info",
+						new GamepadUIGenericConfirmationPanel( this, "SaveOverwriteConfirmationPanel", "#GameUI_ConfirmOverwriteSaveGame_Title", "#GameUI_ConfirmOverwriteSaveGame_Info",
 						[this, pSave]()
 						{
 							SaveGame( pSave );


### PR DESCRIPTION
Closing the save overwrite confirmation panel causes it to start drawing the main menu behind the save game panel. This PR fixes that by changing the dialog's parent to the save game panel instead of the base panel.