### PR TITLE
Fix display mode option starting with full screen regardless of actual display mode

### DIFF
--- a/src/game/gamepadui/gamepadui_options.cpp
+++ b/src/game/gamepadui/gamepadui_options.cpp
@@ -929,7 +929,13 @@ int GetCurrentDisplayMode()
         return 0;
     }
 
+#ifdef HL2_RETAIL
     return 2 + GetSDLDisplayIndex();
+#else
+    // TODO FIXME: SDK2013 uses the inverse here...1 is "windowed" and 0 is "fullscreen" in materialsystem.
+    // but our values mean the opposite in gamepadUI code. (Madi)
+    return 1 + GetSDLDisplayIndex();
+#endif
 }
 
 


### PR DESCRIPTION
Currently, when the Options menu is opened, the "Display mode" option always starts with "Full screen" regardless of whether the game is running in full screen or not. If the user is running the game in a window and applies options changes without changing anything, the game will switch to full screen.

This seems to happen because the code used to get the user's current display mode does not account for borderless window support not existing in Source SDK 2013. A hack which accounts for this can already be found in `FlushPendingResolution()`, and this PR just extends that to `GetCurrentDisplayMode()`.